### PR TITLE
Add requirements.txt file for project dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyephem
+pygubu
+psutil


### PR DESCRIPTION
Extracted these dependencies from the BrukerPy guide V2 document. That way users can run `pip install -r requirements.txt`